### PR TITLE
Add explicit `async` to example in project README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You add middleware with the `with()` function, as shown above.
 The signature for a middleware function is:
 
 ```javascript
-(request, next) => {
+async (request, next) => {
    // alter request
    let response = await next(request)
    // alter response


### PR DESCRIPTION
To improve the copy/paste-ness of the example, `async` should be added, as it is required for the `await` to work.